### PR TITLE
Change exec resource name when creating RSA private key

### DIFF
--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -91,8 +91,9 @@ define accounts::account(
         # $home = $ret[$::fqdn][0]['parameters']['home']
         #
         # TODO: Fix unless so that it replaces the key
-        exec { "/bin/echo '${::accounts::ssh_keys[$name]['private']}' > ~${user}/.ssh/id_rsa":
-          unless => "/usr/bin/test -f ~${user}/.ssh/id_rsa",
+        exec { "put ssh private key ${name} for user ${user}":
+          command => "/bin/echo '${::accounts::ssh_keys[$name]['private']}' > ~${user}/.ssh/id_rsa",
+          unless  => "/usr/bin/test -f ~${user}/.ssh/id_rsa",
         }
       }
     }

--- a/spec/classes/accounts_spec.rb
+++ b/spec/classes/accounts_spec.rb
@@ -213,7 +213,7 @@ describe 'accounts' do
     it { is_expected.to have_user_resource_count(1) }
     it { is_expected.to contain_user('foo') }
 
-    it { is_expected.to contain_exec("/bin/echo 'FOO-S-RSA-PRIVATE-KEY' > ~foo/.ssh/id_rsa").with({
+    it { is_expected.to contain_exec("put ssh private key foo for user foo").with({
       :unless => '/usr/bin/test -f ~foo/.ssh/id_rsa',
     })}
   end
@@ -254,7 +254,7 @@ describe 'accounts' do
     it { is_expected.to have_user_resource_count(1) }
     it { is_expected.to contain_user('foo') }
 
-    it { is_expected.to contain_exec("/bin/echo 'FOO-S-RSA-PRIVATE-KEY' > ~foo/.ssh/id_rsa").with({
+    it { is_expected.to contain_exec("put ssh private key foo for user foo").with({
       :unless => '/usr/bin/test -f ~foo/.ssh/id_rsa',
     })}
   end


### PR DESCRIPTION
- avoid ~ in ressource name (puppetdb doesn't like it atm)
- avoid having the private key in the resource name/tag
