### PR TITLE
Default users 'membership' to 'inclusive'

### DIFF
--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -3,6 +3,7 @@ define accounts::account(
   $ensure                   = present,
   $user                     = $name,
   $groups                   = [],
+  $groups_membership        = $::accounts::groups_membership,
   $authorized_keys          = [],
   $authorized_keys_target   = undef,
   $purge_ssh_keys           = $::accounts::purge_ssh_keys,
@@ -38,6 +39,7 @@ define accounts::account(
           groups         => $groups,
           home           => "/home/${$name}",
           managehome     => true,
+          membership     => $groups_membership,
         },
         $::accounts::users[$name]
       )

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # See README.md for details.
 class accounts(
   $groups                   = {},
+  $groups_membership        = undef,
   $ssh_keys                 = {},
   $users                    = {},
   $usergroups               = {},


### PR DESCRIPTION
This allows removing users from groups by making the groups array
'inclusive' (user belongs to these groups and no more) instead of
a 'minimum'. It also insures that the users' rights are more tightly managed.

Should this be a configurable default?