### PR TITLE
create user's group with custom gid before creating the user

### DIFF
--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -77,11 +77,24 @@ define accounts::account(
         $_hash = $hash
       }
 
-      ensure_resource(
-        group,
-        $user,
-        {ensure => $_hash[ensure], gid => $_hash[gid]}
-      )
+      # if you're giving a user's primary group a custom GID, you need to create
+      # it before you create the user. the puppet user type assumes the GID
+      # you're giving it for user's primary group already exists. in the case
+      # where you don't specify the GID, puppet just selects the next available
+      # GID.
+      #
+      # in the case where we're deleting the user, puppet will delete the user's
+      # primary group automatically, regardless of what the GID is set to. but
+      # if you try to delete the user's primary group before deleting the user,
+      # you'll get an error about how you "cannot remove the primary group of
+      # user blah"
+      if $ensure != absent {
+        ensure_resource(
+          group,
+          $user,
+          {gid => $_hash[gid]}
+        )
+      }
 
       ensure_resource(
         user,

--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -76,6 +76,13 @@ define accounts::account(
       } else {
         $_hash = $hash
       }
+
+      ensure_resource(
+        group,
+        $user,
+        {gid => $_hash[gid]}
+      )
+
       ensure_resource(
         user,
         $user,

--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -80,7 +80,7 @@ define accounts::account(
       ensure_resource(
         group,
         $user,
-        {gid => $_hash[gid]}
+        {ensure => $_hash[ensure], gid => $_hash[gid]}
       )
 
       ensure_resource(

--- a/spec/defines/accounts__account_spec.rb
+++ b/spec/defines/accounts__account_spec.rb
@@ -129,17 +129,13 @@ class { 'accounts':
         })}
       end
 
-      context 'when removing user with custom gid' do
+      context 'when removing user' do
         let(:title) { 'matt' }
         let(:params) {{
           :ensure => 'absent',
         }}
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to have_user_resource_count(1) }
-        it { is_expected.to contain_group('matt').with({
-          :name           => 'matt',
-          :ensure         => 'absent',
-        })}
         it { is_expected.to contain_user('matt').with({
           :name           => 'matt',
           :ensure         => 'absent',

--- a/spec/defines/accounts__account_spec.rb
+++ b/spec/defines/accounts__account_spec.rb
@@ -129,6 +129,23 @@ class { 'accounts':
         })}
       end
 
+      context 'when removing user with custom gid' do
+        let(:title) { 'matt' }
+        let(:params) {{
+          :ensure => 'absent',
+        }}
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_user_resource_count(1) }
+        it { is_expected.to contain_group('matt').with({
+          :name           => 'matt',
+          :ensure         => 'absent',
+        })}
+        it { is_expected.to contain_user('matt').with({
+          :name           => 'matt',
+          :ensure         => 'absent',
+        })}
+      end
+
       context 'when user and custom gid' do
         let(:title) { 'matt' }
         it { is_expected.to compile.with_all_deps }

--- a/spec/defines/accounts__account_spec.rb
+++ b/spec/defines/accounts__account_spec.rb
@@ -103,6 +103,7 @@ class { 'accounts':
     'matt'  => {
       'comment' => 'Matt M.',
       'uid'     => 1009,
+      'gid'     => 6666,
     },
   },
   usergroups => {
@@ -125,6 +126,26 @@ class { 'accounts':
           :key    => "An_Ankou's_Key",
           :type   => 'ssh-rsa',
           :user   => 'foo',
+        })}
+      end
+
+      context 'when user and custom gid' do
+        let(:title) { 'matt' }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_user_resource_count(1) }
+        it { is_expected.to contain_group('matt').with({
+          :name           => 'matt',
+          :gid            => 6666,
+        })}
+        it { is_expected.to contain_user('matt').with({
+          :name           => 'matt',
+          :ensure         => 'present',
+          :comment        => 'Matt M.',
+          :groups         => [],
+          :home           => '/home/matt',
+          :managehome     => true,
+          :uid            => 1009,
+          :gid            => 6666,
         })}
       end
 


### PR DESCRIPTION
The README.md shows an example of hard coding a UID but that functionality isn't in the module right now. Pull request #14 has it so I merged it and resolved the merge conflict. 

Specifying the GID is also a nice feature, also included in pull request #14 but if you do that, you need go create the group for the user (with the specified GID) before you create the user. Puppet does autorequire the group for the user, but just selects the next GID available, you need to manually create the group if you want a custom GID. See error below for what happens if you try to create a user with a custom UID and GID:

```
Error: Could not create user example: Execution of '/sbin/useradd -g 66666 -d /home/example -p * -u 66666 -m example' returned 6: useradd: group '66666' does not exist
Error: /Stage[main]/Profiles::Base/Accounts::Account[@herp]/Accounts::Account[example]/User[example]/ensure: change from absent to present failed: Could not create user example: Execution of '/sbin/useradd -g 66666 -d /home/example -p * -u 66666 -m example' returned 6: useradd: group '66666' does not exist
```
