### PR TITLE
Create user's group with custom GID before creating the user.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,13 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                                              :require => false
-  gem 'rspec', '< 3.2',                                    :require => false if RUBY_VERSION =~ /^1\.8/
+  if RUBY_VERSION =~ /^1\.8/
+    gem 'rake',  '< 11',                                   :require => false
+    gem 'rspec', '>= 3', '< 3.2',                          :require => false
+  else
+    gem 'rake',                                            :require => false
+    gem 'rspec', '~> 3.0',                                 :require => false
+  end
   gem 'rspec-puppet',                                      :require => false
   gem 'puppetlabs_spec_helper',                            :require => false
   gem 'metadata-json-lint',                                :require => false

--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -78,6 +78,26 @@ define accounts::account(
       } else {
         $_hash = $hash
       }
+
+      # if you're giving a user's primary group a custom GID, you need to create
+      # it before you create the user. the puppet user type assumes the GID
+      # you're giving it for user's primary group already exists. in the case
+      # where you don't specify the GID, puppet just selects the next available
+      # GID.
+      #
+      # in the case where we're deleting the user, puppet will delete the user's
+      # primary group automatically, regardless of what the GID is set to. but
+      # if you try to delete the user's primary group before deleting the user,
+      # you'll get an error about how you "cannot remove the primary group of
+      # user blah"
+      if $ensure != absent {
+        ensure_resource(
+          group,
+          $user,
+          {gid => $_hash[gid]}
+        )
+      }
+
       ensure_resource(
         user,
         $user,

--- a/spec/defines/accounts__account_spec.rb
+++ b/spec/defines/accounts__account_spec.rb
@@ -103,6 +103,7 @@ class { 'accounts':
     'matt'  => {
       'comment' => 'Matt M.',
       'uid'     => 1009,
+      'gid'     => 6666,
     },
   },
   usergroups => {
@@ -143,6 +144,26 @@ class { 'accounts':
           :home           => '/home/matt',
           :managehome     => false,
           :uid            => 1009,
+        })}
+      end
+
+      context 'when user and custom gid' do
+        let(:title) { 'matt' }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to have_user_resource_count(1) }
+        it { is_expected.to contain_group('matt').with({
+          :name           => 'matt',
+          :gid            => 6666,
+        })}
+        it { is_expected.to contain_user('matt').with({
+          :name           => 'matt',
+          :ensure         => 'present',
+          :comment        => 'Matt M.',
+          :groups         => [],
+          :home           => '/home/matt',
+          :managehome     => true,
+          :uid            => 1009,
+          :gid            => 6666,
         })}
       end
 


### PR DESCRIPTION
Custom UID and GID are able to be specified for each user, but if the group doesn't already exist the user's new group is not created before attempting to create the new user.

You would recieve a message similar to the following:

```
Error: Could not create user example: Execution of '/sbin/useradd -g 66666 -d /home/example -p * -u 66666 -m example' returned 6: useradd: group '66666' does not exist
Error: /Stage[main]/Profiles::Base/Accounts::Account[@herp]/Accounts::Account[example]/User[example]/ensure: change from absent to present failed: Could not create user example: Execution of '/sbin/useradd -g 66666 -d /home/example -p * -u 66666 -m example' returned 6: useradd: group '66666' does not exist
```

Without specifying a custom GID Puppet will autorequire the group for the user and select the next available GID

This commit modifies account.pp to create the new group with custom GID prior to creating the user.

Deletion of the group, regardless of the GID, will happen automatically when the user is purged using this module.