### PR TITLE
Ensure that when we mark users absent, that their homedir is managed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class accounts(
   # Remove users marked as absent
   $absent_users = keys(absents($users))
   user { $absent_users:
-    ensure => absent,
+    ensure     => absent,
+    managehome => $managehome,
   }
 }


### PR DESCRIPTION
Currently, when a user is marked absent, their home directory is left behind. This is because $managehome isn't being passed down to the init.pp absent user section.
