### PR TITLE
Fix puppet error if the account is not yet created

### DIFF
--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -133,6 +133,7 @@ define accounts::account(
         exec { "put ssh private key ${name} for user ${user}":
           command => "/bin/echo '${::accounts::ssh_keys[$name]['private']}' > ~${user}/.ssh/id_rsa; /bin/chown ${user} ~${user}/.ssh/id_rsa; /bin/chmod 600 ~${user}/.ssh/id_rsa",
           unless  => "/usr/bin/test -f ~${user}/.ssh/id_rsa",
+          onlyif  => "/usr/bin/test -d ~${user}/.ssh",
         }
       }
     }


### PR DESCRIPTION
Hi there ;)
I had an error when pushing accounts through hiera and providing a private key... It generates an error when creating the private key as the user home folder doesn't exist at the time the command is run. It would be better with a require but I don't know how to require a resource from a custom module. At least this patch avoid any errors and deploy the private key at next run.

Tell me what you think about this one... Is it possible to do this with a require?
