### PR TITLE
Add additional prerequisite

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=3.2.0 <5.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_shellvar",
+      "version_requirement": ">=2.2.1 < 3.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
In order to support having a starting UID, the SHELLVAR resource
type is needed, which is not part of a default installation. This
adds in a prerequisite which provides the necessary Augeas provider.