### PR TITLE
Correcting issue #15

### DIFF
--- a/manifests/authorized_key.pp
+++ b/manifests/authorized_key.pp
@@ -41,7 +41,7 @@ define accounts::authorized_key(
       ssh_authorized_key { $_ssh_authorized_key_title:
         ensure  => $ensure,
         key     => $::accounts::ssh_keys[$ssh_key]['public'],
-        options => $options,
+        options => $::accounts::ssh_keys[$ssh_key]['options'],
         target  => $_target,
         type    => $::accounts::ssh_keys[$ssh_key]['type'],
         user    => $_user,


### PR DESCRIPTION
I can't write a proper unit test for this issue, but this PR enable to specify ssh options on authorized_keys like this:

```yaml
accounts::ssh_keys:
  bob:
    type: ssh-rsa
    public: AAAAB3NzaC1yc2EAAAADA4Kx+uyjdJtYdwngM7fGud
    options:
      - command="/usr/bin/ls /tmp"
      - no-agent-forwarding
      - no-port-forwarding
      - no-pty
      - no-user-rc
      - no-X11-forwarding
```
