### PR TITLE
Allow ssh_options for accounts being created through accounts::usergr…

### DIFF
--- a/manifests/account.pp
+++ b/manifests/account.pp
@@ -40,6 +40,7 @@ define accounts::account(
         password                 => $password,
         uid                      => $uid,
         gid                      => $gid,
+        ssh_options              => $ssh_options,
       }
     )
   } else {


### PR DESCRIPTION
…oups as well

If you create an account using accounts::accounts and the user name directly, you can put ssh_options as well. With that patch, you can specify ssh_options even though you define a user group with @user_group. I haven't found another way to provide ssh_options without having to define every single user. With that you can ensure specific ssh_options being set for all users within that group.