### PR TITLE
🐛 Remove deprecated validate_ functions

### DIFF
--- a/manifests/authorized_key.pp
+++ b/manifests/authorized_key.pp
@@ -13,8 +13,6 @@ define accounts::authorized_key (
   Optional[String] $target         = undef,
   String $ssh_authorized_key_title = $accounts::ssh_authorized_key_title,
 ) {
-  validate_hash($accounts::ssh_keys)
-
   # Retrieve $ssh_keys and $users in the current scope
   $ssh_keys = $accounts::ssh_keys
   $users    = $accounts::users


### PR DESCRIPTION
This is checked here : 
https://github.com/camptocamp/puppet-accounts/blob/master/manifests/init.pp#L18

fixes #74 